### PR TITLE
Optimize approval checks in Bitbucket reviewer utils

### DIFF
--- a/src/main/java/tk/lightweightcoding/jenkins/bitbucket/approval/utils/BitbucketReviewerUtils.java
+++ b/src/main/java/tk/lightweightcoding/jenkins/bitbucket/approval/utils/BitbucketReviewerUtils.java
@@ -11,22 +11,14 @@ public class BitbucketReviewerUtils {
     }
 
     public static boolean hasAuthorApproval(Collection<BitbucketReviewer> reviewers, BitbucketPullRequest pullRequest) {
-        boolean hasAuthorApproval = false;
-
-        for (BitbucketReviewer reviewer : reviewers) {
-            hasAuthorApproval = hasAuthorApproval || (reviewer.getApproved() && BitbucketReviewerUtils.isApprovalAuthor(reviewer, pullRequest));
-        }
-
-        return hasAuthorApproval;
+        return reviewers.stream()
+                .filter(BitbucketReviewer::getApproved)
+                .anyMatch(bitbucketReviewer -> BitbucketReviewerUtils.isApprovalAuthor(bitbucketReviewer, pullRequest));
     }
 
     public static boolean hasNonAuthorApproval(Collection<BitbucketReviewer> reviewers, BitbucketPullRequest pullRequest) {
-        boolean hasNonAuthorApproval = false;
-
-        for (BitbucketReviewer reviewer : reviewers) {
-            hasNonAuthorApproval = hasNonAuthorApproval || (reviewer.getApproved() && !BitbucketReviewerUtils.isApprovalAuthor(reviewer, pullRequest));
-        }
-
-        return hasNonAuthorApproval;
+        return reviewers.stream()
+                .filter(BitbucketReviewer::getApproved)
+                .anyMatch(bitbucketReviewer -> !BitbucketReviewerUtils.isApprovalAuthor(bitbucketReviewer, pullRequest));
     }
 }


### PR DESCRIPTION
I noticed that before both filters would iterate through all entires
regardless of whether it had already found an author or a non author
approval. I've switched to using filters and streams as well as anyMatch
which should short circuit and hopefully be more efficient when sorting
through long lists of potential approvers