### PR TITLE
[Hacktoberfest] Migrate docs to jenkinsci repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,17 @@
 # Jenkins Bitbucket Pull Request Approval Plugin
 
-This repository is a Jenkins plugin that interacts with the [Bitbucket Branch Source Plugin](https://github.com/jenkinsci/bitbucket-branch-source-plugin)
-and provides the extended ability of only allowing pull requests that have an approval or a non-author approval before building.
+This repository is a Jenkins plugin that interacts with the [Bitbucket Branch Source Plugin](https://github.com/jenkinsci/bitbucket-branch-source-plugin) and provides the extended ability of only allowing pull requests that have an approval or a non-author approval before building.
+
+Note: There is a known issue with using the Basic Branch Build Strategies plugin with named branches not building when using this plugin.
+
+The different approval statuses supported are: 
+
+-   No Approval Necessary
+    -   This is the same behavior as not having the plugin installed.
+        Approvals have no affect on whether a pull request will be built or not.
+-   Any Approval Required
+    -   Before being built, a pull request must have an approval. 
+        This approval could come from the author of the pull request.
+-   Non-Author Approval Required
+    -   Before being built a pull request must have an approval that is from a user that is not the author.
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     </properties>
     <name>Bitbucket Approval Filter</name>
     <description>Filters that requires pull request to be approved before building.</description>
-    <url>https://github.com/jenkinsci/bitbucket-approval-filter-plugin/url>
+    <url>https://github.com/jenkinsci/bitbucket-approval-filter-plugin</url>
     <licenses>
         <license>
             <name>MIT License</name>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     </properties>
     <name>Bitbucket Approval Filter</name>
     <description>Filters that requires pull request to be approved before building.</description>
-    <url>https://wiki.jenkins.io/display/JENKINS/Bitbucket+Approval+Filter+Plugin</url>
+    <url>https://github.com/jenkinsci/bitbucket-approval-filter-plugin/url>
     <licenses>
         <license>
             <name>MIT License</name>


### PR DESCRIPTION
This PR migrates the Bitbucket Approval Filter plugin documentation from the plugins-wiki-docs repo to the bitbucket-approval-filter repo as part of the Hacktoberfest docs-to-code project. It includes the following changes:

- Merges the wiki documentation with the existing Readme documentation
- Updates the pom.xml file with the new documentation URL

Please let me know if you have any questions.

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did